### PR TITLE
Fix cli messages

### DIFF
--- a/app/application.py
+++ b/app/application.py
@@ -394,12 +394,6 @@ def create_transcript(data):
 def initialize():
     logger = logging.getLogger(__app_name__)
     try:
-        logger.info(
-            """
-        This tool will convert Youtube videos to mp3 files and then transcribe\
-         them to text using Whisper.
-        """
-        )
         # FFMPEG installed on first use.
         logger.debug("Initializing FFMPEG...")
         static_ffmpeg.add_paths()

--- a/transcriber.py
+++ b/transcriber.py
@@ -167,6 +167,10 @@ def add(
     else:
         logging.getLogger().setLevel(logging.WARNING)
 
+    logging.info(
+        " This tool will convert Youtube videos to mp3 files and then "
+        "transcribe them to text using Whisper. "
+    )
     try:
         username = application.get_username()
         loc = loc.strip("/")


### PR DESCRIPTION
The `transcriber.py` makes the library a cli tool. Moving the cli-output from `app/application.py` to `transcriber.py`.